### PR TITLE
Override Sepolia superchain config

### DIFF
--- a/superchain/configs/sepolia/superchain.yaml
+++ b/superchain/configs/sepolia/superchain.yaml
@@ -7,6 +7,8 @@ l1:
 protocol_versions_addr: "0x79ADD5713B383DAa0a138d3C4780C7A1804a8090"
 superchain_config_addr: "0xC2Be75506d5724086DEB7245bd260Cc9753911Be"
 
-canyon_time: 1699981200 # Tue Nov 14 17:00:00 UTC 2023
-delta_time: 1703203200  # Fri Dec 22 00:00:00 UTC 2023
-ecotone_time: 1708534800 # Wed Feb 21 17:00:00 UTC 2024
+# boba overriden
+canyon_time: 1705600788 # Thu Jan 18 2024 17:59:48 UTC 2024
+regolith_time: 1705600788 # Thu Jan 18 2024 17:59:48 UTC 2024
+delta_time: 1709078400 # Wed Feb 28 2024 00:00:00 UTC 2024
+ecotone_time: 1709078400 # Wed Feb 28 2024 00:00:00 UTC 2024


### PR DESCRIPTION
The superchain uses the same hardfork times, so we have to override it.